### PR TITLE
Fix warning "invalid suffix on literal"

### DIFF
--- a/include/methods.h
+++ b/include/methods.h
@@ -95,21 +95,21 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     {icsname_no_icsneo, (PyCFunction)meth, flags, "\n.. note:: Compatibility Function\n\tIdentical to PEP8 compliant :func:`" MODULE_NAME "." name "` method.\n\n"}
 
 #define _DOC_FIND_DEVICES \
-    MODULE_NAME".find_devices(device_type="MODULE_NAME".NEODEVICE_ALL)\n" \
+    MODULE_NAME ".find_devices(device_type=" MODULE_NAME ".NEODEVICE_ALL)\n" \
     "\n" \
-    "Finds all connected devices and returns a tuple of :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"` for use in :func:`"MODULE_NAME".open_device`\n" \
+    "Finds all connected devices and returns a tuple of :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "` for use in :func:`" MODULE_NAME ".open_device`\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice_type (int): Accepts "MODULE_NAME".NEODEVICE_* Macros\n\n" \
+    "\tdevice_type (int): Accepts " MODULE_NAME ".NEODEVICE_* Macros\n\n" \
     "\t*New in 3.0 (803):*\n\n" \
-    "\tdevice_type (List/Tuple): Accepts a Container of "MODULE_NAME".NEODEVICE_* Macros\n\n" \
+    "\tdevice_type (List/Tuple): Accepts a Container of " MODULE_NAME ".NEODEVICE_* Macros\n\n" \
     "\tstOptionsOpenNeoEx (int): Usually ics.NETID_CAN, if needed\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
-    "\tTuple of :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"` for use in :func:`"MODULE_NAME".open_device`\n" \
+    "\tTuple of :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "` for use in :func:`" MODULE_NAME ".open_device`\n" \
     "\n" \
     "\t>>> for device in ics.find_devices():\n" \
     "\t...     print(device.Name, device.SerialNumber)\n" \
@@ -123,13 +123,13 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
 
 
 #define _DOC_OPEN_DEVICES \
-    MODULE_NAME".open_device(device)\n" \
+    MODULE_NAME ".open_device(device)\n" \
     "\n" \
-    "Opens the device. `device` can be omitted to return a :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"` of the\n" \
-    "first free availible device, a :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`, or a serial number of the device.\n" \
+    "Opens the device. `device` can be omitted to return a :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "` of the\n" \
+    "first free availible device, a :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`, or a serial number of the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\tdevice (int): Serial Number of the device\n\n" \
     "\tbNetworkIDs (int): Network Enables\n\n" \
     "\tbConfigRead (int): Config Read\n\n" \
@@ -137,29 +137,29 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\tstOptionsOpenNeoEx (int): Usually ics.NETID_CAN, if needed\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
-    "\tIf :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"` is passed as a parameter, None. \n" \
-    "\tIf serial number is passed as a parameter, a :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"` will be returned. \n" \
-    "\tIf `device` parameter is omitted, a :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"` will be returned with the first availible free device. \n" \
+    "\tIf :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "` is passed as a parameter, None. \n" \
+    "\tIf serial number is passed as a parameter, a :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "` will be returned. \n" \
+    "\tIf `device` parameter is omitted, a :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "` will be returned with the first availible free device. \n" \
     "\n" \
     "\t>>> for device in ics.find_devices():\n" \
     "\t...     ics.open_device(device)\n" \
     "\t...\n" \
     "\n" \
-    ".. note::\n\t:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"` will automatically close the device when it goes out of scope.\n\n"
+    ".. note::\n\t:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "` will automatically close the device when it goes out of scope.\n\n"
 
 #define _DOC_CLOSE_DEVICES \
-    MODULE_NAME".close_device(device)\n" \
+    MODULE_NAME ".close_device(device)\n" \
     "\n" \
     "Closes the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tError Count (int)\n" \
@@ -170,18 +170,18 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t...     ics.close_device(device)\n" \
     "\t...\n" \
     "\n" \
-    ".. note::\n\t:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"` will automatically close the device when it goes out of scope.\n\n" \
+    ".. note::\n\t:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "` will automatically close the device when it goes out of scope.\n\n" \
 
 #define _DOC_GET_RTC \
-    MODULE_NAME".get_rtc(device)\n" \
+    MODULE_NAME ".get_rtc(device)\n" \
     "\n" \
     "Gets the Real-Time Clock of the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tTuple: (datetime.datetime object, offset in seconds)\n" \
@@ -191,16 +191,16 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t(datetime.datetime(2014, 9, 10, 17, 45, 45), 3)\n"
 
 #define _DOC_SET_RTC \
-    MODULE_NAME".set_rtc(device[, time])\n" \
+    MODULE_NAME ".set_rtc(device[, time])\n" \
     "\n" \
     "Sets the Real-Time Clock of the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\time (:class:`datetime.datetime`): Optional. Sets to current time, if omitted.\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tNone.\n" \
@@ -209,17 +209,17 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t>>> ics.set_rtc(device)\n"
 
 #define _DOC_COREMINI_LOAD \
-    MODULE_NAME".coremini_load(device, coremini, location)\n" \
+    MODULE_NAME ".coremini_load(device, coremini, location)\n" \
     "\n" \
     "Loads the CoreMini into the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\tcoremini (str/tuple): Use string to load from file, Use Tuple if file data.\n\n" \
-    "\tlocation (int): Accepts :class:`"MODULE_NAME".SCRIPT_LOCATION_FLASH_MEM`, :class:`"MODULE_NAME".SCRIPT_LOCATION_SDCARD`, or :class:`"MODULE_NAME".SCRIPT_LOCATION_VCAN3_MEM`\n\n" \
+    "\tlocation (int): Accepts :class:`" MODULE_NAME ".SCRIPT_LOCATION_FLASH_MEM`, :class:`" MODULE_NAME ".SCRIPT_LOCATION_SDCARD`, or :class:`" MODULE_NAME ".SCRIPT_LOCATION_VCAN3_MEM`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tNone.\n" \
@@ -228,16 +228,16 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t>>> ics.coremini_load(device, 'cmvspy.vs3cmb', ics.SCRIPT_LOCATION_SDCARD)\n"
 
 #define _DOC_COREMINI_START \
-    MODULE_NAME".coremini_start(device, location)\n" \
+    MODULE_NAME ".coremini_start(device, location)\n" \
     "\n" \
     "Starts the CoreMini into the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
-    "\tlocation (int): Accepts :class:`"MODULE_NAME".SCRIPT_LOCATION_FLASH_MEM`, :class:`"MODULE_NAME".SCRIPT_LOCATION_SDCARD`, or :class:`"MODULE_NAME".SCRIPT_LOCATION_VCAN3_MEM`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
+    "\tlocation (int): Accepts :class:`" MODULE_NAME ".SCRIPT_LOCATION_FLASH_MEM`, :class:`" MODULE_NAME ".SCRIPT_LOCATION_SDCARD`, or :class:`" MODULE_NAME ".SCRIPT_LOCATION_VCAN3_MEM`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tNone.\n" \
@@ -246,15 +246,15 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t>>> ics.coremini_start(device, ics.SCRIPT_LOCATION_SDCARD)\n"
 
 #define _DOC_COREMINI_STOP \
-    MODULE_NAME".coremini_stop(device)\n" \
+    MODULE_NAME ".coremini_stop(device)\n" \
     "\n" \
     "Stops the CoreMini into the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tNone.\n" \
@@ -263,16 +263,16 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t>>> ics.coremini_stop(device)\n"
 
 #define _DOC_COREMINI_CLEAR \
-    MODULE_NAME".coremini_clear(device, location)\n" \
+    MODULE_NAME ".coremini_clear(device, location)\n" \
     "\n" \
     "Clears the CoreMini into the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
-    "\tlocation (int): Accepts :class:`"MODULE_NAME".SCRIPT_LOCATION_FLASH_MEM`, :class:`"MODULE_NAME".SCRIPT_LOCATION_SDCARD`, or :class:`"MODULE_NAME".SCRIPT_LOCATION_VCAN3_MEM`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
+    "\tlocation (int): Accepts :class:`" MODULE_NAME ".SCRIPT_LOCATION_FLASH_MEM`, :class:`" MODULE_NAME ".SCRIPT_LOCATION_SDCARD`, or :class:`" MODULE_NAME ".SCRIPT_LOCATION_VCAN3_MEM`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tNone.\n" \
@@ -281,15 +281,15 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t>>> ics.coremini_clear(device, ics.SCRIPT_LOCATION_SDCARD)\n"
 
 #define _DOC_COREMINI_GET_STATUS \
-    MODULE_NAME".coremini_get_status(device)\n" \
+    MODULE_NAME ".coremini_get_status(device)\n" \
     "\n" \
     "Gets the status of the CoreMini in the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tTrue if running, otherwise False.\n" \
@@ -299,16 +299,16 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t>>>\n"
 
 #define _DOC_TRANSMIT_MESSAGES \
-    MODULE_NAME".transmit_messages(device, messages)\n" \
+    MODULE_NAME ".transmit_messages(device, messages)\n" \
     "\n" \
-    "Transmits message(s) on the device. `messages` can be a tuple of :class:`"MODULE_NAME"."SPY_MESSAGE_OBJECT_NAME"`\n" \
+    "Transmits message(s) on the device. `messages` can be a tuple of :class:`" MODULE_NAME "." SPY_MESSAGE_OBJECT_NAME "`\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
-    "\tmessages (:class:`"MODULE_NAME"."SPY_MESSAGE_OBJECT_NAME"`): :class:`"MODULE_NAME"."SPY_MESSAGE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
+    "\tmessages (:class:`" MODULE_NAME "." SPY_MESSAGE_OBJECT_NAME "`): :class:`" MODULE_NAME "." SPY_MESSAGE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tNone.\n" \
@@ -322,20 +322,20 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t>>>\n"
 
 #define _DOC_GET_MESSAGES \
-    MODULE_NAME".get_messages(device[, j1850, timeout])\n" \
+    MODULE_NAME ".get_messages(device[, j1850, timeout])\n" \
     "\n" \
     "Gets the message(s) on the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
-    "\tj1850 (:class:`bool`): Return :class:`"MODULE_NAME"."SPY_MESSAGE_J1850_OBJECT_NAME"` instead.\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
+    "\tj1850 (:class:`bool`): Return :class:`" MODULE_NAME "." SPY_MESSAGE_J1850_OBJECT_NAME "` instead.\n\n" \
     "\timeout (:class:`float`): Optional timeout to wait for messages in seconds (0.1 = 100ms).\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
-    "\t:class:`tuple` of two items. First item is a :class:`tuple` of :class:`"MODULE_NAME"."SPY_MESSAGE_OBJECT_NAME"` and second is the error count.\n" \
+    "\t:class:`tuple` of two items. First item is a :class:`tuple` of :class:`" MODULE_NAME "." SPY_MESSAGE_OBJECT_NAME "` and second is the error count.\n" \
     "\n" \
     "\t>>> device = ics.open_device()\n" \
     "\t>>> messages, errors = ics.get_messages(device)\n" \
@@ -350,15 +350,15 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
 
 //"Accepts a " MODULE_NAME "." NEO_DEVICE_OBJECT_NAME ", exception on error. Returns a list of (error #, string)"
 #define _DOC_GET_ERROR_MESSAGES \
-    MODULE_NAME".get_error_messages(device[, j1850, timeout])\n" \
+    MODULE_NAME ".get_error_messages(device[, j1850, timeout])\n" \
     "\n" \
     "Gets the error message(s) on the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\t:class:`list` of :class:`tuple`s. :class:`tuple` contents: (error_number, description_short, description_long, severity, restart_needed)\n" \
@@ -369,7 +369,7 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
 
 //_DOC_SET_REFLASH_DISPLAY_CALLBACKS), "icsneoSetReflashCallback(), pass a python function func(msg, progress)"
 #define _DOC_SET_REFLASH_CALLBACK \
-    MODULE_NAME".set_reflash_callback(callback)\n" \
+    MODULE_NAME ".set_reflash_callback(callback)\n" \
     "\n" \
     "Sets the reflash display callback.\n" \
     "\n" \
@@ -377,7 +377,7 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\tcallback (:class:`function`): Must be a callable Python function (`def callback(msg, progress)`)\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tNone.\n" \
@@ -390,18 +390,18 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
 
 #if defined(USE_GENERIC_DEVICE_SETTINGS)
 #define _DOC_GET_DEVICE_SETTINGS \
-    MODULE_NAME".get_device_settings(device, vnet_slot)\n" \
+    MODULE_NAME ".get_device_settings(device, vnet_slot)\n" \
     "\n" \
-    "Gets the settings in the device. vnet_slot defaults to "MODULE_NAME".PlasmaIonVnetChannelMain\n" \
+    "Gets the settings in the device. vnet_slot defaults to " MODULE_NAME ".PlasmaIonVnetChannelMain\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
-    "\t:class:`"MODULE_NAME"."DEVICE_SETTINGS_OBJECT_NAME"`\n" \
+    "\t:class:`" MODULE_NAME "."DEVICE_SETTINGS_OBJECT_NAME"`\n" \
     "\n" \
     "\t>>> d = ics.open_device()\n" \
     "\t>>> d.Name\n" \
@@ -424,18 +424,18 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t4\n"
 #else
 #define _DOC_GET_DEVICE_SETTINGS \
-    MODULE_NAME".get_device_settings(device, device_type)\n" \
+    MODULE_NAME ".get_device_settings(device, device_type)\n" \
     "\n" \
     "Gets the settings in the device. device_type can override which setting object we deal with normally\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
-    "\t:class:`"MODULE_NAME"."VCAN3_SETTINGS_OBJECT_NAME"` or :class:`"MODULE_NAME"."FIRE_SETTINGS_OBJECT_NAME"`.\n" \
+    "\t:class:`" MODULE_NAME "." VCAN3_SETTINGS_OBJECT_NAME "` or :class:`" MODULE_NAME "." FIRE_SETTINGS_OBJECT_NAME "`.\n" \
     "\n" \
     "\t>>> device = ics.open_device()\n" \
     "\t>>> settings = ics.get_device_settings(device)\n" \
@@ -446,16 +446,16 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
 
 #if defined(USE_GENERIC_DEVICE_SETTINGS)
     #define _DOC_SET_DEVICE_SETTINGS \
-    MODULE_NAME".set_device_settings(device, settings, save_to_eeprom, vnet_slot)\n" \
+    MODULE_NAME ".set_device_settings(device, settings, save_to_eeprom, vnet_slot)\n" \
     "\n" \
-    "Sets the settings in the device. vnet_slot defaults to "MODULE_NAME".PlasmaIonVnetChannelMain\n" \
+    "Sets the settings in the device. vnet_slot defaults to " MODULE_NAME ".PlasmaIonVnetChannelMain\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
-    "\tsettings (:class:`"MODULE_NAME"."DEVICE_SETTINGS_OBJECT_NAME"`): :class:`"MODULE_NAME"."DEVICE_SETTINGS_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
+    "\tsettings (:class:`" MODULE_NAME "."DEVICE_SETTINGS_OBJECT_NAME"`): :class:`" MODULE_NAME "."DEVICE_SETTINGS_OBJECT_NAME"`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tNone.\n" \
@@ -475,18 +475,18 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t>>> \n"
 #else // #if defined(USE_GENERIC_DEVICE_SETTINGS)
 #define _DOC_SET_DEVICE_SETTINGS \
-    MODULE_NAME".set_device_settings(device, settings, device_type, save_to_eeprom)\n" \
+    MODULE_NAME ".set_device_settings(device, settings, device_type, save_to_eeprom)\n" \
     "\n" \
     "Sets the settings in the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
-    "\tsettings (:class:`"MODULE_NAME"."VCAN3_SETTINGS_OBJECT_NAME"`): :class:`"MODULE_NAME"."VCAN3_SETTINGS_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
+    "\tsettings (:class:`" MODULE_NAME "." VCAN3_SETTINGS_OBJECT_NAME "`): :class:`" MODULE_NAME "." VCAN3_SETTINGS_OBJECT_NAME "`\n\n" \
     "\tor:\n\n" \
-    "\tsettings (:class:`"MODULE_NAME"."FIRE_SETTINGS_OBJECT_NAME"`): :class:`"MODULE_NAME"."FIRE_SETTINGS_OBJECT_NAME"`\n\n" \
+    "\tsettings (:class:`" MODULE_NAME "." FIRE_SETTINGS_OBJECT_NAME "`): :class:`" MODULE_NAME "." FIRE_SETTINGS_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tNone.\n" \
@@ -504,15 +504,15 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
 
 //"Accepts a " MODULE_NAME "." NEO_DEVICE_OBJECT_NAME ", exception on error."
 #define _DOC_LOAD_DEFAULT_SETTINGS \
-    MODULE_NAME".load_default_settings(device)\n" \
+    MODULE_NAME ".load_default_settings(device)\n" \
     "\n" \
     "Load the default settings in the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tNone.\n" \
@@ -522,7 +522,7 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t>>> \n"
 
 #define _DOC_CREATE_NEOVI_RADIO_MESSAGE \
-    MODULE_NAME".create_neovi_radio_message(Relay1, Relay2, Relay3, Relay4, Relay5, LED6, LED5, MSB_report_rate, LSB_report_rate, analog_change_report_rate, relay_timeout)\n\n" \
+    MODULE_NAME ".create_neovi_radio_message(Relay1, Relay2, Relay3, Relay4, Relay5, LED6, LED5, MSB_report_rate, LSB_report_rate, analog_change_report_rate, relay_timeout)\n\n" \
     "Python API only. Generates data bytes for use with neoVI RADI/O CAN Messages\n\n" \
     "Kwargs:\n" \
     "\tRelay1 (boolean): Enable/Disable Relay1\n\n" \
@@ -539,10 +539,10 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\n" \
     "Returns:\n" \
     "\n" \
-    "\tTuple of data bytes for use with :class:`"MODULE_NAME"."SPY_MESSAGE_OBJECT_NAME"`\n" \
+    "\tTuple of data bytes for use with :class:`" MODULE_NAME "." SPY_MESSAGE_OBJECT_NAME "`\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "\t>>> msg = ics.SpyMessage()\n" \
     "\t>>> msg.Data = ics.create_neovi_radio_message(Relay1=True, Relay4=False, LED6=True, MSB_report_rate=10)\n" \
@@ -550,16 +550,16 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t(65, 10, 0, 0, 0)\n"
 
 #define _DOC_COREMINI_START_FBLOCK \
-    MODULE_NAME".coremini_start_fblock(device, index)\n" \
+    MODULE_NAME ".coremini_start_fblock(device, index)\n" \
     "\n" \
     "Starts a Coremini Function Block at `index` on `device`.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\tindex (int): Index of the function block.\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tNone on Success.\n" \
@@ -568,16 +568,16 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t>>> ics.coremini_start_fblock(device, 1)\n"
 
 #define _DOC_COREMINI_STOP_FBLOCK \
-    MODULE_NAME".coremini_stop_fblock(device, index)\n" \
+    MODULE_NAME ".coremini_stop_fblock(device, index)\n" \
     "\n" \
     "Stops a Coremini Function Block at `index` on `device`.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\tindex (int): Index of the function block.\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tNone on Success.\n" \
@@ -586,16 +586,16 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t>>> ics.coremini_stop_fblock(device, 1)\n"
 
 #define _DOC_COREMINI_GET_FBLOCK_STATUS \
-    MODULE_NAME".coremini_get_fblock_status(device, index)\n" \
+    MODULE_NAME ".coremini_get_fblock_status(device, index)\n" \
     "\n" \
     "Gets the status of a Coremini Function Block at `index` on `device`.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\tindex (int): Index of the function block.\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tNone on Success.\n" \
@@ -605,16 +605,16 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\tTrue\n"
 
 #define _DOC_COREMINI_READ_APP_SIGNAL \
-    MODULE_NAME".coremini_read_app_signal(device, index)\n" \
+    MODULE_NAME ".coremini_read_app_signal(device, index)\n" \
     "\n" \
     "Gets the value of a Coremini application signal at `index` on `device`.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\tindex (int): Index of the application signal.\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tint on Success.\n" \
@@ -624,17 +624,17 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t52\n"
 
 #define _DOC_COREMINI_WRITE_APP_SIGNAL \
-    MODULE_NAME".coremini_write_app_signal(device, index, value)\n" \
+    MODULE_NAME ".coremini_write_app_signal(device, index, value)\n" \
     "\n" \
     "Sets the value of a Coremini application signal at `index` on `device`.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\tindex (int): Index of the application signal.\n\n" \
     "\tvalue (int): New value of the application signal.\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tNone on Success.\n" \
@@ -644,61 +644,61 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t>>>\n"
 
 #define _DOC_COREMINI_READ_TX_MESSAGE \
-    MODULE_NAME".coremini_read_tx_message(device, index, j1850=False)\n" \
+    MODULE_NAME ".coremini_read_tx_message(device, index, j1850=False)\n" \
     "\n" \
     "Gets the value of a Coremini Message at `index` on `device`.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\tindex (int): Index of the application signal.\n\n" \
-    "\tj1850 (bool): Use :class:`"MODULE_NAME"."SPY_MESSAGE_J1850_OBJECT_NAME"` instead.\n\n" \
+    "\tj1850 (bool): Use :class:`" MODULE_NAME "." SPY_MESSAGE_J1850_OBJECT_NAME "` instead.\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
-    "\t:class:`"MODULE_NAME"."SPY_MESSAGE_OBJECT_NAME"` Success.\n" \
+    "\t:class:`" MODULE_NAME "." SPY_MESSAGE_OBJECT_NAME "` Success.\n" \
     "\n" \
     "\t>>> device = ics.open_device()\n" \
     "\t>>> msg = ics.coremini_read_tx_message(device, 0)\n"
 
 #define _DOC_COREMINI_READ_RX_MESSAGE \
-    MODULE_NAME".coremini_read_rx_message(device, index, j1850=False)\n" \
+    MODULE_NAME ".coremini_read_rx_message(device, index, j1850=False)\n" \
     "\n" \
     "Gets the value of a Coremini Message at `index` on `device`.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\tindex (int): Index of the application signal.\n\n" \
-    "\tj1850 (bool): Use :class:`"MODULE_NAME"."SPY_MESSAGE_J1850_OBJECT_NAME"` instead.\n\n" \
+    "\tj1850 (bool): Use :class:`" MODULE_NAME "." SPY_MESSAGE_J1850_OBJECT_NAME "` instead.\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
-    "\t:class:`"MODULE_NAME"."SPY_MESSAGE_OBJECT_NAME"` Success.\n" \
+    "\t:class:`" MODULE_NAME "." SPY_MESSAGE_OBJECT_NAME "` Success.\n" \
     "\n" \
     "\t>>> device = ics.open_device()\n" \
     "\t>>> msg = ics.coremini_read_tx_message(device, 0)\n"
 
 #define _DOC_COREMINI_WRITE_TX_MESSAGE \
-    MODULE_NAME".coremini_write_tx_message(device, index, msg)\n" \
+    MODULE_NAME ".coremini_write_tx_message(device, index, msg)\n" \
     "TODO"
 
 #define _DOC_COREMINI_WRITE_RX_MESSAGE \
-    MODULE_NAME".coremini_write_rx_message(device, index, TODO)\n" \
+    MODULE_NAME ".coremini_write_rx_message(device, index, TODO)\n" \
     "TODO"
 
 #define _DOC_GET_PERFORMANCE_PARAMETERS \
-    MODULE_NAME".get_performance_parameters(device)\n" \
+    MODULE_NAME ".get_performance_parameters(device)\n" \
     "\n" \
     "Gets the Performance Parameters on `device`.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tTuple on Success: (buffer count, buffer max, overflow count, reserved, reserved, reserved, reserved, reserved)\n" \
@@ -708,17 +708,17 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t(0, 24576, 0, 0, 0, 0, 0, 0)\n"
 
 #define _DOC_VALIDATE_HOBJECT \
-    MODULE_NAME".validate_hobject(device)\n" \
+    MODULE_NAME ".validate_hobject(device)\n" \
     "\n" \
     "Validates the handle is valid for a `device`. Handles are only valid when the device is open.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\tor:\n\n" \
     "\tdevice (int): c style integer handle to the device.\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tBoolean: True if valid, false otherwise.\n" \
@@ -730,15 +730,15 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t1\n"
 
 #define _DOC_GET_LAST_API_ERROR \
-    MODULE_NAME".get_last_api_error(device)\n" \
+    MODULE_NAME ".get_last_api_error(device)\n" \
     "\n" \
     "Gets the error message from the last API call.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tTuple: (error, description short, description long, severity, restart needed)\n" \
@@ -754,7 +754,7 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t(224, 'Invalid Message Index for script.', 'Invalid Message Index for script.', 16, 0)\n" 
 
 #define _DOC_GET_DLL_VERSION \
-    MODULE_NAME".get_dll_version(device)\n" \
+    MODULE_NAME ".get_dll_version(device)\n" \
     "\n" \
     "Gets the DLL version.\n" \
     "\n" \
@@ -762,7 +762,7 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\tNone\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tInt: DLL Version\n" \
@@ -771,7 +771,7 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t700\n"
 
 #define _DOC_BASE36ENC \
-    MODULE_NAME".base36enc(serial)\n" \
+    MODULE_NAME ".base36enc(serial)\n" \
     "\n" \
     "Converts a decimal serial number to base36.\n" \
     "\n" \
@@ -779,7 +779,7 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\tserial (int): serial number.\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tStr: Serial Number\n" \
@@ -788,15 +788,15 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\tCY0024\n"
 
 #define _DOC_GET_SERIAL_NUMBER \
-    MODULE_NAME".get_serial_number(device)\n" \
+    MODULE_NAME ".get_serial_number(device)\n" \
     "\n" \
     "Gets the serial number out of the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tInt: Serial Number Version\n" \
@@ -805,7 +805,7 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t53123\n"
 
 #define _DOC_REQUEST_ENTER_SLEEP_MODE \
-    MODULE_NAME".request_enter_sleep_mode(device, timeout_ms, mode, reserved_zero)\n" \
+    MODULE_NAME ".request_enter_sleep_mode(device, timeout_ms, mode, reserved_zero)\n" \
     "\n" \
     "Signal neoVI to immediete go to sleep. Currently only supported by FIREVNET/PLASMA.\n" \
     "If using over USB this will likely return true but never cause PLASMA to sleep\n" \
@@ -813,7 +813,7 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "This API allows Android/Linux applications to invoke power management.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "\ttimeout_ms (int): 16bit word for how long to wait on idle bus before going to sleep. " \
         "If caller does not want to change it pass in 65535 (0xFFFF) and it " \
@@ -831,7 +831,7 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\treserved_zero (int): Reserved, Keep as zero.\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tBoolean: True on success, False on failure.\n" \
@@ -841,7 +841,7 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
 
 
 #define _DOC_SET_CONTEXT \
-    MODULE_NAME".set_context(device)\n" \
+    MODULE_NAME ".set_context(device)\n" \
     "\n" \
     "Sets the \"context\" of how icsneoFindNeoDevices(Ex) and icsneoOpenNeoDevice(Ex)\n" \
     "function. If the context is 0 (null) than icsneoFindNeoDevices(Ex) will be system\n" \
@@ -852,10 +852,10 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "create logical connections to found CAN Nodes.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tBoolean: True on success, False on failure.\n" \
@@ -864,15 +864,15 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\tTrue\n"
 
 #define _DOC_FORCE_FIRMWARE_UPDATE \
-    MODULE_NAME".force_firmware_update(device)\n" \
+    MODULE_NAME ".force_firmware_update(device)\n" \
     "\n" \
     "Forces the device to flash firmware.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tBoolean: True on success, False on failure.\n" \
@@ -881,15 +881,15 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\tTrue\n"
 
 #define _DOC_FIRMWARE_UPDATE_REQUIRED \
-    MODULE_NAME".firmware_update_required(device)\n" \
+    MODULE_NAME ".firmware_update_required(device)\n" \
     "\n" \
     "Determines if the device firmware needs flashing.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tBoolean: True on success, False on failure.\n" \
@@ -898,18 +898,18 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\tTrue\n"
 
 #define _DOC_GET_DLL_FIRMWARE_INFO \
-    MODULE_NAME".get_dll_firmware_info(device)\n" \
+    MODULE_NAME ".get_dll_firmware_info(device)\n" \
     "\n" \
     "Returns the DLL firmware info for the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
-    "\t(:class:`"MODULE_NAME"."API_FIRMWARE_INFO_OBJECT_NAME"`)\n" \
+    "\t(:class:`" MODULE_NAME "." API_FIRMWARE_INFO_OBJECT_NAME "`)\n" \
     "\n" \
     "\t>>> device = ics.open_device()\n" \
     "\t>>> info = ics.get_dll_firmware_info(device)\n" \
@@ -920,18 +920,18 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t>>>\n"
 
 #define _DOC_GET_HW_FIRMWARE_INFO \
-    MODULE_NAME".get_hw_firmware_info(device)\n" \
+    MODULE_NAME ".get_hw_firmware_info(device)\n" \
     "\n" \
     "Returns the device firmware info for the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
-    "\t(:class:`"MODULE_NAME"."API_FIRMWARE_INFO_OBJECT_NAME"`)\n" \
+    "\t(:class:`" MODULE_NAME "." API_FIRMWARE_INFO_OBJECT_NAME "`)\n" \
     "\n" \
     "\t>>> device = ics.open_device()\n" \
     "\t>>> info = ics.get_hw_firmware_info(device)\n" \
@@ -942,45 +942,45 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t>>>\n"
 
 #define _DOC_GET_BACKUP_POWER_ENABLED \
-    MODULE_NAME".get_backup_power_enabled(device)\n" \
+    MODULE_NAME ".get_backup_power_enabled(device)\n" \
     "\n" \
     "Returns the device backup power enabled for the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tBoolean: True on success, False on failure.\n" \
     "\n"
 
 #define _DOC_SET_BACKUP_POWER_ENABLED \
-    MODULE_NAME".set_backup_power_enabled(device, enable)\n" \
+    MODULE_NAME ".set_backup_power_enabled(device, enable)\n" \
     "\n" \
     "Sets the device backup power enabled for the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tBoolean: True on success, False on failure.\n" \
     "\n"
 
 #define _DOC_GET_BACKUP_POWER_READY \
-    MODULE_NAME".get_backup_power_ready(device)\n" \
+    MODULE_NAME ".get_backup_power_ready(device)\n" \
     "\n" \
     "Returns the device backup power is ready for the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tBoolean: True on success, False on failure.\n" \
@@ -991,17 +991,17 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
 
 // void* hObject, unsigned long ulNetworkID, stCM_ISO157652_TxMessage *pMsg, unsigned long ulBlockingTimeout
 #define _DOC_ISO15765_TRANSMIT_MESSAGE \
-    MODULE_NAME".iso15765_transmit_message(device, ulNetworkID, pMsg, ulBlockingTimeout)\n" \
+    MODULE_NAME ".iso15765_transmit_message(device, ulNetworkID, pMsg, ulBlockingTimeout)\n" \
     "\n" \
     "Transmits an ISO15765 Message.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
-    "\tpMsg (:class:`"MODULE_NAME"."CM_ISO157652_TX_MESSAGE_OBJECT_NAME"`): :class:`"MODULE_NAME"."CM_ISO157652_TX_MESSAGE_OBJECT_NAME"`\n\n" \
+    "\tpMsg (:class:`" MODULE_NAME "." CM_ISO157652_TX_MESSAGE_OBJECT_NAME "`): :class:`" MODULE_NAME "." CM_ISO157652_TX_MESSAGE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tBoolean: True on success, False on failure.\n" \
@@ -1009,84 +1009,84 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
 
 // (void* hObject, unsigned int iIndex, const stCM_ISO157652_RxMessage * pRxMessage)
 #define _DOC_ISO15765_RECEIVE_MESSAGE \
-    MODULE_NAME".iso15765_receive_message(device, netid, rx_msg)\n" \
+    MODULE_NAME ".iso15765_receive_message(device, netid, rx_msg)\n" \
     "\n" \
     "Setup rx ISO15765 Message.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
-    "\tprx_msg (:class:`"MODULE_NAME"."CM_ISO157652_RX_MESSAGE_OBJECT_NAME"`): :class:`"MODULE_NAME"."CM_ISO157652_RX_MESSAGE_OBJECT_NAME"`\n\n" \
+    "\tprx_msg (:class:`" MODULE_NAME "." CM_ISO157652_RX_MESSAGE_OBJECT_NAME "`): :class:`" MODULE_NAME "." CM_ISO157652_RX_MESSAGE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tBoolean: True on success, False on failure.\n" \
     "\n"
 
 #define _DOC_ISO15765_ENABLE_NETWORKS \
-    MODULE_NAME".iso15765_enable_networks(device, networks)\n" \
+    MODULE_NAME ".iso15765_enable_networks(device, networks)\n" \
     "\n" \
     "Enables ISO15765 networks.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tNone\n" \
     "\n"
 
 #define _DOC_ISO15765_DISABLE_NETWORKS \
-    MODULE_NAME".iso15765_disable_networks(device)\n" \
+    MODULE_NAME ".iso15765_disable_networks(device)\n" \
     "\n" \
     "Disables ISO15765 networks.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tNone\n" \
     "\n"
 
 #define _DOC_GET_ACTIVE_VNET_CHANNEL \
-    MODULE_NAME".get_active_vnet_channel(device)\n" \
+    MODULE_NAME ".get_active_vnet_channel(device)\n" \
     "\n" \
     "Gets active vnet channel for the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tInt: Returns active vnet channel.\n" \
     "\n"
 
 #define _DOC_SET_ACTIVE_VNET_CHANNEL \
-    MODULE_NAME".set_active_vnet_channel(device, channel)\n" \
+    MODULE_NAME ".set_active_vnet_channel(device, channel)\n" \
     "\n" \
     "Sets active vnet channel for the device.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tBoolean: True on success, False on failure.\n" \
     "\n"
 
 #define _DOC_OVERRIDE_LIBRARY_NAME \
-    MODULE_NAME".override_library_name(new_name)\n" \
+    MODULE_NAME ".override_library_name(new_name)\n" \
     "\n" \
     "Sets active vnet channel for the device.\n" \
     "\n" \
@@ -1094,7 +1094,7 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\tname: Absolute path or relative path including filename.\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tNone\n" \
@@ -1109,62 +1109,62 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t(<ics.NeoDevice object at 0x00284C50>, <ics.NeoDevice object at 0x007C9A10>)\n"
 
 #define _DOC_SET_BIT_RATE \
-    MODULE_NAME".set_bit_rate(device, BitRate, NetworkID)\n" \
+    MODULE_NAME ".set_bit_rate(device, BitRate, NetworkID)\n" \
     "\n" \
     "Sets the bitrate for a given Network ID on the device..\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tInt: None.\n" \
     "\n"
 
 #define _DOC_SET_FD_BIT_RATE \
-    MODULE_NAME".set_fd_bit_rate(device, BitRate, NetworkID)\n" \
+    MODULE_NAME ".set_fd_bit_rate(device, BitRate, NetworkID)\n" \
     "\n" \
     "Sets the FD bitrate for a given Network ID on the device..\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tInt: None.\n" \
     "\n"
 
 #define _DOC_SET_BIT_RATE_EX \
-    MODULE_NAME".set_fd_bit_rate_ex(device, BitRate, NetworkID, iOptions)\n" \
+    MODULE_NAME ".set_fd_bit_rate_ex(device, BitRate, NetworkID, iOptions)\n" \
     "\n" \
     "Sets the bitrate for a given Network ID on the device with extended options.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tInt: None.\n" \
     "\n"
 
 #define _DOC_GET_TIMESTAMP_FOR_MSG \
-    MODULE_NAME".get_timestamp_for_msg(device, msg)\n" \
+    MODULE_NAME ".get_timestamp_for_msg(device, msg)\n" \
     "\n" \
     "Calculates the timestamp for a message.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
-    "\tmsg (:class:`"MODULE_NAME"."SPY_MESSAGE_OBJECT_NAME"`): :class:`"MODULE_NAME"."SPY_MESSAGE_OBJECT_NAME"`\n\n" \
+    "\tmsg (:class:`" MODULE_NAME "." SPY_MESSAGE_OBJECT_NAME "`): :class:`" MODULE_NAME "." SPY_MESSAGE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tFloat: Timestamp for the message.\n" \
@@ -1176,18 +1176,18 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t354577568.9145524\n" \
 
 #define _DOC_GET_DEVICE_STATUS \
-    MODULE_NAME".get_device_status(device)\n" \
+    MODULE_NAME ".get_device_status(device)\n" \
     "\n" \
     "Returns the device status.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
-    "\t(:class:`"MODULE_NAME"."ICS_DEVICE_STATUS_OBJECT_NAME"`).\n" \
+    "\t(:class:`" MODULE_NAME "." ICS_DEVICE_STATUS_OBJECT_NAME "`).\n" \
     "\n" \
     "\t>>> import ics\n" \
     "\t>>> d = ics.open_device()\n" \
@@ -1196,19 +1196,19 @@ PyObject* meth_enable_network_com(PyObject* self, PyObject* args); //icsneoEnabl
     "\t0\n" \
 
 #define _DOC_ENABLE_NETWORK_COM \
-    MODULE_NAME".enable_network_com(device, enable, net_id)\n" \
+    MODULE_NAME ".enable_network_com(device, enable, net_id)\n" \
     "\n" \
     "Enable or disable network communication.\n" \
     "\n" \
     "Args:\n" \
-    "\tdevice (:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`): :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"`\n\n" \
+    "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\n" \
     "\tenable (:class:`bool`): :class:`bool`\n\n" \
     "\n" \
     "\tnet_id (:class:`int`): :class:`int`: Optional. If left blank, disables/enables all networks.\n\n" \
     "\n" \
     "Raises:\n" \
-    "\t:class:`"MODULE_NAME".RuntimeError`\n" \
+    "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
     "\tNone.\n" \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,11 +57,11 @@
     "\t...\n" \
     "\tneoVI FIRE 59886\n" \
     "\n" \
-    "It should be noted that :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"` is used a little bit differently than the C API.\n" \
-    ":class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"` contains two extra members:\n" \
-    "\t:class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME".AutoHandleClose` and :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"._Handle`\n" \
+    "It should be noted that :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "` is used a little bit differently than the C API.\n" \
+    ":class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "` contains two extra members:\n" \
+    "\t:class:`" MODULE_NAME"." NEO_DEVICE_OBJECT_NAME ".AutoHandleClose` and :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "._Handle`\n" \
     "The handle normally returned from `icsneoOpenNeoDevice()` is stored inside _Handle and setting AutoHandleClose to True (Default)\n" \
-    "will automatically close the handle when the :class:`"MODULE_NAME"."NEO_DEVICE_OBJECT_NAME"` goes out of scope.\n" \
+    "will automatically close the handle when the :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "` goes out of scope.\n" \
     "\n" \
     "\n" \
     "Installation:\n" \


### PR DESCRIPTION
Fix warnings: ````invalid suffix on literal; C++11 requires a space between literal and string macro [-Wliteral-suffix]````