### PR TITLE
Release the GIL for the whole duration of timeout

### DIFF
--- a/src/methods.cpp
+++ b/src/methods.cpp
@@ -959,10 +959,10 @@ PyObject* meth_get_messages(PyObject* self, PyObject* args)
             PyErr_Print();
             return set_ics_exception_dev(exception_runtime_error(), obj, "Failed to allocate " SPY_MESSAGE_OBJECT_NAME);
         }
+        Py_BEGIN_ALLOW_THREADS
         for (double i=timeout; i > 0; --i) {
             count = 20000;
             errors = 0;
-            Py_BEGIN_ALLOW_THREADS
             if (!icsneoGetMessages(handle, (icsSpyMessage*)msgs, &count, &errors) && !errors) {
                 // We are going to try one more time just incase
                 count = 20000;
@@ -972,7 +972,6 @@ PyObject* meth_get_messages(PyObject* self, PyObject* args)
                     return set_ics_exception_dev(exception_runtime_error(), obj, "icsneoGetMessages() Failed");
                 }
             }
-            Py_END_ALLOW_THREADS
             if (count || errors) {
                 break;
             }
@@ -981,6 +980,7 @@ PyObject* meth_get_messages(PyObject* self, PyObject* args)
                 Sleep(1);
             }
         }
+        Py_END_ALLOW_THREADS
         PyObject* tuple = PyTuple_New(count);
         for (int i=0; i < count; ++i) {
             PyObject* obj = NULL;


### PR DESCRIPTION
Release the GIL for the whole duration of timeout instead of release and acquiring once per interval (every 1 ms).