### PR TITLE
Py_BuildValue with format "s" take in a const char *

### DIFF
--- a/src/methods.cpp
+++ b/src/methods.cpp
@@ -4141,7 +4141,7 @@ PyObject* meth_get_library_path(PyObject* self)
             char buffer[512];
             return set_ics_exception(exception_runtime_error(), dll_get_error(buffer));
         }
-        return Py_BuildValue("s", lib->getPath());
+        return Py_BuildValue("s", lib->getPath().c_str());
     }
     catch (ice::Exception& ex)
     {


### PR DESCRIPTION
In some cases, this can cause a segmentation fault

(cherry picked from commit 95f3c1df4e1ff9e701064faef8d2af57e5cb1301)