### PR TITLE
Fixing code comment

### DIFF
--- a/src/exceptions.cpp
+++ b/src/exceptions.cpp
@@ -92,7 +92,7 @@ PyObject* _set_ics_exception_dev(PyObject* exception, PyObject* obj, char* msg, 
         }
         char* b36sn = pyics_base36enc(PyNeoDevice_GetSerialNumber(obj));
         ss << PyNeoDevice_GetSerialNumber(obj);
-        if (b36sn != NULL && PyNeoDevice_GetSerialNumber(obj) >= 604661760 /* "A0000" */) {
+        if (b36sn != NULL && PyNeoDevice_GetSerialNumber(obj) >= 604661760 /* "A00000" */) {
             ss << " - " << b36sn << ")";
         } else {
             ss << ")";


### PR DESCRIPTION
Also according to https://github.com/intrepidcs/python_ics/blob/0afd6d49e9610b4f47931a333bb590f9c6d312b9/include/object_neo_device.h#L136  this should be `AA0000`/`621457920`