### PR TITLE
Using correct value type in coremini read/write app signal

### DIFF
--- a/include/methods.h
+++ b/include/methods.h
@@ -618,7 +618,7 @@ PyObject* meth_get_bus_voltage(PyObject* self, PyObject* args);
     "\t:class:`" MODULE_NAME ".RuntimeError`\n" \
     "\n" \
     "Returns:\n" \
-    "\tint on Success.\n" \
+    "\tfloat on Success.\n" \
     "\n" \
     "\t>>> device = ics.open_device()\n" \
     "\t>>> ics.coremini_read_app_signal(device, 1)\n" \
@@ -632,7 +632,7 @@ PyObject* meth_get_bus_voltage(PyObject* self, PyObject* args);
     "Args:\n" \
     "\tdevice (:class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`): :class:`" MODULE_NAME "." NEO_DEVICE_OBJECT_NAME "`\n\n" \
     "\tindex (int): Index of the application signal.\n\n" \
-    "\tvalue (int): New value of the application signal.\n\n" \
+    "\tvalue (float): New value of the application signal.\n\n" \
     "\n" \
     "Raises:\n" \
     "\t:class:`" MODULE_NAME ".RuntimeError`\n" \

--- a/src/methods.cpp
+++ b/src/methods.cpp
@@ -2720,7 +2720,7 @@ PyObject* meth_coremini_read_app_signal(PyObject* self, PyObject* args) //Script
             return set_ics_exception(exception_runtime_error(), "icsneoScriptReadAppSignal() Failed");
         }
         Py_END_ALLOW_THREADS
-        return Py_BuildValue("i", value);
+        return Py_BuildValue("d", value);
     }
     catch (ice::Exception& ex)
     {
@@ -2734,7 +2734,7 @@ PyObject* meth_coremini_write_app_signal(PyObject* self, PyObject* args) //Scrip
     int index;
     PyObject* obj = NULL;
     double value = 0;
-    if (!PyArg_ParseTuple(args, arg_parse("Oii:", __FUNCTION__), &obj, &index, &value)) {
+    if (!PyArg_ParseTuple(args, arg_parse("Oid:", __FUNCTION__), &obj, &index, &value)) {
         return NULL;
     }
     if (!PyNeoDevice_CheckExact(obj)) {


### PR DESCRIPTION
`meth_coremini_read_app_signal` was incorrectly returning a python `int` instead of a python `float`. The `double` to python `int` conversion was resulting in always returning 0.

`meth_coremini_write_app_signa` was incorrectly taking a python `int` for the value argument instead of a python `float`.