### PR TITLE
Fix macOS Structure Generation

### DIFF
--- a/generate_icsneo40_structs.py
+++ b/generate_icsneo40_structs.py
@@ -121,12 +121,7 @@ class CObject(object):
 
 def is_line_start_of_object(line):
     "Returns True if we are a c object (enum, struct, union)"
-    def find_whole_word(w):
-        return re.compile(r'\b({0})\b'.format(w), flags=re.IGNORECASE).search
-    
-    object_names = ('enum', 'struct', 'union')
-    is_start = [x for x in object_names if find_whole_word(x)(line) != None]
-    return bool(is_start)
+    return bool(re.search('\btypedef struct$|struct$|struct \S*$|enum|union', line))
 
 # This contains all the objects that don't pass convert_to_ctype_object
 NON_CTYPE_OBJ_NAMES = []

--- a/generate_icsneo40_structs.py
+++ b/generate_icsneo40_structs.py
@@ -136,7 +136,7 @@ ALL_C_OBJECTS = []
 def get_object_from_name(name):
     global ALL_C_OBJECTS
     for obj in ALL_C_OBJECTS:
-        if name in obj.preferred_name or name in obj.names:
+        if name == obj.preferred_name or name in obj.names:
             return obj
     return None
 

--- a/generate_icsneo40_structs.py
+++ b/generate_icsneo40_structs.py
@@ -545,7 +545,13 @@ def generate(filename='include/ics/icsnVC40.h'):
         shutil.rmtree(output_dir)
     except FileNotFoundError:
         pass
-    ignore_names = ['__fsid_t', '__darwin_pthread_handler_rec', '_mbstate_t', 'NeoDevice', 'neo_device', 'NeoDeviceEx', 'neo_device_ex', 'icsSpyMessage', 'icsSpyMessageJ1850', 'ics_spy_message', 'ics_spy_message_j1850'] 
+    ignore_names = [
+        '__fsid_t', '__darwin_pthread_handler_rec', '_mbstate_t',
+        '_opaque_pthread_attr_t', '_opaque_pthread_cond_t', '_opaque_pthread_condattr_t',
+        '_opaque_pthread_mutex_t', '_opaque_pthread_mutexattr_t', '_opaque_pthread_once_t',
+        '_opaque_pthread_rwlock_t', '_opaque_pthread_rwlockattr_t', '_opaque_pthread_t',
+        'NeoDevice', 'neo_device', 'NeoDeviceEx', 'neo_device_ex',
+        'icsSpyMessage', 'icsSpyMessageJ1850', 'ics_spy_message', 'ics_spy_message_j1850']
     file_names = []
     prefered_names = []
     all_objects = c_objects + enum_objects

--- a/generate_icsneo40_structs.py
+++ b/generate_icsneo40_structs.py
@@ -545,7 +545,7 @@ def generate(filename='include/ics/icsnVC40.h'):
         shutil.rmtree(output_dir)
     except FileNotFoundError:
         pass
-    ignore_names = ['__fsid_t', '__darwin_pthread_handler_rec', '_mbstate_t' 'NeoDevice', 'neo_device', 'NeoDeviceEx', 'neo_device_ex', 'icsSpyMessage', 'icsSpyMessageJ1850', 'ics_spy_message', 'ics_spy_message_j1850'] 
+    ignore_names = ['__fsid_t', '__darwin_pthread_handler_rec', '_mbstate_t', 'NeoDevice', 'neo_device', 'NeoDeviceEx', 'neo_device_ex', 'icsSpyMessage', 'icsSpyMessageJ1850', 'ics_spy_message', 'ics_spy_message_j1850'] 
     file_names = []
     prefered_names = []
     all_objects = c_objects + enum_objects


### PR DESCRIPTION
The main thing here was that we were not properly handling member types prefixed with the `struct` keyword at time of member declaration.

Closes #107 