### PR TITLE
Moving cibuildwheel configuration to pyproject.toml

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,21 +21,6 @@ jobs:
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
-        env:
-          CIBW_BUILD: "{*-win32,*-win_amd64,*-macosx_universal2,*-manylinux_x86_64,*-manylinux_aarch64}"
-          CIBW_SKIP: cp36-* pp* *-manylinux_i686 *-musllinux_*
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
-          #CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux_2_28_i686
-          CIBW_ARCHS_MACOS: universal2
-          CIBW_ENVIRONMENT: DISTUTILS_DEBUG=1
-          CIBW_BEFORE_BUILD: >
-            python -m pip install wheel
-          CIBW_BEFORE_BUILD_LINUX: >
-            dnf install -y clang clang-tools-extra
-          CIBW_BEFORE_BUILD_MACOS: >
-            brew install automake libtool cmake clang-format
-          CIBW_BEFORE_BUILD_WINDOWS: >
-            choco install llvm
 
       - uses: actions/upload-artifact@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.cibuildwheel]
+build = "{*-win32,*-win_amd64,*-macosx_universal2,*-manylinux_x86_64,*-manylinux_aarch64}"
+skip = "cp36-* pp* *-manylinux_i686 *-musllinux_*"
+environment = {DISTUTILS_DEBUG=1}
+before-build = "python -m pip install wheel"
+manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64"
+
+[tool.cibuildwheel.linux]
+before-build = "dnf install -y clang clang-tools-extra"
+
+[tool.cibuildwheel.macos]
+archs = ["universal2"]
+before-build = "brew install automake libtool cmake clang-format"
+
+[tool.cibuildwheel.windows]
+before-build = "choco install llvm"


### PR DESCRIPTION
This allows to use cibuildwheel outside Github actions and makes it easier to test/modify the cibuildwheel configurations.