### PR TITLE
Fix icsneoLoadDefaultSettings args

### DIFF
--- a/src/methods.cpp
+++ b/src/methods.cpp
@@ -1469,7 +1469,7 @@ PyObject* meth_load_default_settings(PyObject* self, PyObject* args) // icsneoLo
         }
         ice::Function<int __stdcall(ICS_HANDLE)> icsneoLoadDefaultSettings(lib, "icsneoLoadDefaultSettings");
         Py_BEGIN_ALLOW_THREADS;
-        if (!icsneoLoadDefaultSettings(PyNeoDevice_GetNeoDevice(obj)->handle)) {
+        if (!icsneoLoadDefaultSettings(handle)) {
             Py_BLOCK_THREADS;
             return set_ics_exception_dev(exception_runtime_error(), obj, "icsneoLoadDefaultSettings() Failed");
         }


### PR DESCRIPTION
The device settings example would throw on calling load_default_settings() with the following:
```
ics.ics.RuntimeError: Error: load_default_settings(): Failed to Retrieve address of function 'icsneoLoadDefaultSettings': dlsym(0x2021f20a0, icsneoLoadDefaultSettings): symbol not found for library '@loader_path/libicsneolegacy.dylib'
```
It was passing an int device handle instead of a device handle object, causing the dynamic library lookup to fail on function signature differences.