### PR TITLE
Append to `ARCHFLAGS` instead of overwriting it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ elif "LINUX" in platform.system().upper():
     compile_args = GCC_COMPILE_ARGS
 elif "DARWIN" in platform.system().upper():
     # Mac doesn't respect the compiler args, but will append with ARCHFLAGS environment variable
-    os.environ["ARCHFLAGS"] = "-std=c++17"
+    os.environ["ARCHFLAGS"] += " -std=c++17"
     compile_args = []
 else:
     compile_args = []


### PR DESCRIPTION
Append to `ARCHFLAGS` instead of overwriting it

Fix https://github.com/intrepidcs/python_ics/issues/168