### PR TITLE
fixed compatibility issue with old NeoDevice namespace.

### DIFF
--- a/ics_utility.py
+++ b/ics_utility.py
@@ -51,6 +51,7 @@ except Exception as ex:
 
 
 from ics.structures import *
+from ics.structures.neo_device import NeoDevice, neo_device
 from ics.hiddenimports import hidden_imports
 try:
     from ics.py_neo_device_ex import PyNeoDeviceEx


### PR DESCRIPTION
`NeoDevice` object used to live in `ics.ics.NeoDevice`, even though we shouldn't really ever be using it, add compatibility for it so older code works.