### PR TITLE
Fixing broken (undefined behavior) ics.find_devices device_type filter

### DIFF
--- a/src/methods.cpp
+++ b/src/methods.cpp
@@ -1054,7 +1054,7 @@ PyObject* meth_find_devices(PyObject* self, PyObject* args, PyObject* keywords)
         if (!_convertListOrTupleToArray(device_types, &device_type_vector))
             return NULL;
         device_types_list_size = static_cast<unsigned int>(device_type_vector.size());
-        device_types_list.reset((new unsigned int(device_types_list_size)));
+        device_types_list.reset(new unsigned int[device_types_list_size]);
         for (unsigned int i = 0; i < device_types_list_size; ++i)
             device_types_list[i] = (unsigned int)PyLong_AsLong(device_type_vector[i]);
     }


### PR DESCRIPTION
Call to ics.find_devices wit a device_type filter value is broken (undefined behavior) due to wrong array reset argument

The fix changes `new unsigned int(device_types_list_size)` → `new unsigned int[device_types_list_size]`, so the allocation matches the `unique_ptr<unsigned int[]>` type and all subsequent `device_types_list[i]` accesses are valid.

Reference: https://en.cppreference.com/cpp/memory/unique_ptr/reset

Fixes https://github.com/intrepidcs/python_ics/issues/231