### PR TITLE
Fix Deploy PyPI: ignore W009/W010 for delvewheel-repaired wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -95,5 +95,11 @@ jobs:
         run: |
           source .venv/bin/activate
           uv pip install check-wheel-contents twine
-          check-wheel-contents ./wheelhouse/*.whl
+          # W009/W010 fire on the delvewheel-repaired Windows wheels, whose
+          # vendored-runtime dir (python_ics.libs/ with msvcp140*.dll) is a
+          # second toplevel entry with no Python modules. That layout is
+          # correct for repaired wheels; a [tool.check-wheel-contents]
+          # toplevel allowlist would instead fail the macOS/Linux wheels,
+          # which don't have the directory.
+          check-wheel-contents --ignore W009,W010 ./wheelhouse/*.whl
           twine upload -u __token__ -p ${{ secrets.PYPI_TOKEN }} --verbose ./wheelhouse/*


### PR DESCRIPTION
Deploy PyPI has been failing on every master push since delvewheel started vendoring the MSVC runtime: `check-wheel-contents` rejects the repaired Windows wheels because `python_ics.libs/` (containing only `msvcp140-*.dll`) is a second toplevel entry (**W009**) with no Python modules (**W010**). That layout is exactly what delvewheel is supposed to produce.

## Fix

Add `--ignore W009,W010` to the check in the deploy job. A `[tool.check-wheel-contents]` `toplevel` allowlist was considered and rejected: the macOS/Linux wheels don't contain `python_ics.libs/` (delocate/auditwheel place libraries differently), so an allowlist would fail those wheels with W201 instead. All other wheel checks stay active.

## Verification

Reproduced locally against the actual artifacts from failing master run [28872960948](https://github.com/intrepidcs/python_ics/actions/runs/28872960948):

- without ignore: all 10 Windows wheels fail with W009+W010, exit 1 (matches the CI log)
- with `--ignore W009,W010`: all 10 wheels report `OK`, exit 0

This unblocks the `1!26.3.9` release upload (checklist item 0 from #234).

🤖 Generated with [Claude Code](https://claude.com/claude-code)