### PR TITLE
Build libicsneo master (icspb/protobuf) in wheel builds

### DIFF
--- a/build_libicsneo.py
+++ b/build_libicsneo.py
@@ -112,6 +112,18 @@ def _build_libpcap():
     subprocess.check_output(["make", "-j" + CPUS], cwd=LIBPCAP_BUILD)
     subprocess.check_output(["make", "install"], cwd=LIBPCAP_BUILD)
 
+def _cmake_ninja_args():
+    # pip's ninja lives inside each isolated build env, and cibuildwheel
+    # deletes that env between python versions. A reused CMake build dir
+    # caches the old (now dead) path in CMAKE_MAKE_PROGRAM and fails at
+    # the next configure, so always override with the current ninja.
+    ninja = shutil.which("ninja")
+    args = ["-G", "Ninja"]
+    if ninja:
+        args.append(f"-DCMAKE_MAKE_PROGRAM={ninja}")
+    return args
+
+
 def _build_libicsneo_linux():
     print("Cleaning libicsneo...")
     subprocess.check_output(["git", "clean", "-xdf"], cwd="libicsneo")
@@ -123,7 +135,7 @@ def _build_libicsneo_linux():
             "cmake",
             # Ninja is required: icspb's protobuf_generate never creates its
             # output dir, and only Ninja pre-creates declared output dirs.
-            "-G", "Ninja",
+            *_cmake_ninja_args(),
             "-DCMAKE_BUILD_TYPE=Release",
             "-DLIBICSNEO_BUILD_ICSNEOLEGACY=ON",
             f"-DCMAKE_PREFIX_PATH={LIBUSB_INSTALL};{LIBPCAP_INSTALL}",
@@ -151,7 +163,7 @@ def _build_libicsneo_macos():
             "cmake",
             # Ninja is required: icspb's protobuf_generate never creates its
             # output dir, and only Ninja pre-creates declared output dirs.
-            "-G", "Ninja",
+            *_cmake_ninja_args(),
             "-DCMAKE_BUILD_TYPE=Release",
             "-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64",
             "-DLIBICSNEO_BUILD_ICSNEOLEGACY=ON",

--- a/build_libicsneo.py
+++ b/build_libicsneo.py
@@ -14,18 +14,28 @@ LIBUSB_SOURCE = f"{LIBUSB_ROOT}/source"
 LIBUSB_BUILD = f"{LIBUSB_ROOT}/build"
 LIBUSB_INSTALL = f"{LIBUSB_ROOT}/install"
 
-# NOTE: this pin's vendored icsnVC40.h predates Vspy 3.26.3.9
+# NOTE: this pin's vendored icsnVC40.h still predates Vspy 3.26.3.9
 # (SRADGalaxy2Settings 840 vs 1204, no Comet3/Gigastar2), so Linux/macOS
-# wheels lag the Windows ABI. Newer upstream doesn't help yet: master
-# (4ed29b4, 2026-07-07) still has the old header AND adds a mandatory
-# icspb protobuf dependency whose codegen fails on clean CI runners.
-# Bump once upstream syncs the header and icspb builds.
-LIBICSNEO_VERSION = "830fe1a"
+# wheels lag the Windows ABI until upstream syncs the header; bump again
+# when it does. libicsneo requires icspb (protobuf) as of 2026: its
+# codegen needs the Ninja generator (protobuf_generate never creates
+# PROTOC_OUT_DIR; Make doesn't pre-create declared output dirs, Ninja
+# does), and it bootstraps protobuf from source at configure time — see
+# ICSPB_BOOTSTRAP_DIR below.
+LIBICSNEO_VERSION = "4ed29b4"
 LIBICSNEO_ROOT = f"{ROOT}/libicsneo/{LIBICSNEO_VERSION}"
 LIBICSNEO_SOURCE = f"{LIBICSNEO_ROOT}/source"
 LIBICSNEO_BUILD = f"{LIBICSNEO_ROOT}/build"
 LIBICSNEO_INSTALL = f"{LIBICSNEO_ROOT}/install"
 print(f"LIBICSNEO PATH: {LIBICSNEO_ROOT}")
+
+# icspb bootstraps protobuf from source at configure time. Keep the
+# bootstrap OUTSIDE the libicsneo build dir so it survives the per-python
+# `git clean` in _build_libicsneo_linux and is reused across all
+# cibuildwheel builds in a job (it self-partitions by <system>-<processor>,
+# so sharing one root across archs is safe). Building protobuf once per
+# arch instead of once per python matters most under QEMU aarch64.
+ICSPB_BOOTSTRAP_DIR = f"{ROOT}/icspb_bootstrap"
 
 LIBPCAP_VERSION = "1.10.4"
 LIBPCAP_ROOT = f"{ROOT}/libpcap/{LIBPCAP_VERSION}"
@@ -111,9 +121,13 @@ def _build_libicsneo_linux():
     subprocess.check_output(
         [
             "cmake",
+            # Ninja is required: icspb's protobuf_generate never creates its
+            # output dir, and only Ninja pre-creates declared output dirs.
+            "-G", "Ninja",
             "-DCMAKE_BUILD_TYPE=Release",
             "-DLIBICSNEO_BUILD_ICSNEOLEGACY=ON",
             f"-DCMAKE_PREFIX_PATH={LIBUSB_INSTALL};{LIBPCAP_INSTALL}",
+            f"-DICSPB_BOOTSTRAP_DIR={ICSPB_BOOTSTRAP_DIR}",
             "-S", LIBICSNEO_SOURCE,
             "-B", LIBICSNEO_BUILD,
             "-Wno-dev",
@@ -125,17 +139,29 @@ def _build_libicsneo_linux():
     )
 
 def _build_libicsneo_macos():
+    env = os.environ.copy()
+    # Set as env vars (not only -D flags) so icspb's nested protobuf
+    # bootstrap — a separate cmake invocation via execute_process, which
+    # inherits the environment but not our -D cache entries — also builds
+    # universal2 static libs instead of arm64-only ones.
+    env["CMAKE_OSX_ARCHITECTURES"] = "arm64;x86_64"
+    env["CMAKE_OSX_DEPLOYMENT_TARGET"] = "10.13"
     subprocess.check_output(
         [
             "cmake",
+            # Ninja is required: icspb's protobuf_generate never creates its
+            # output dir, and only Ninja pre-creates declared output dirs.
+            "-G", "Ninja",
             "-DCMAKE_BUILD_TYPE=Release",
             "-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64",
             "-DLIBICSNEO_BUILD_ICSNEOLEGACY=ON",
             "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13",
             f"-DCMAKE_PREFIX_PATH={LIBUSB_INSTALL};{LIBPCAP_INSTALL}",
+            f"-DICSPB_BOOTSTRAP_DIR={ICSPB_BOOTSTRAP_DIR}",
             "-S", LIBICSNEO_SOURCE,
             "-B", LIBICSNEO_BUILD
-        ]
+        ],
+        env=env,
     )
 
     subprocess.check_output(

--- a/build_libicsneo.py
+++ b/build_libicsneo.py
@@ -14,15 +14,14 @@ LIBUSB_SOURCE = f"{LIBUSB_ROOT}/source"
 LIBUSB_BUILD = f"{LIBUSB_ROOT}/build"
 LIBUSB_INSTALL = f"{LIBUSB_ROOT}/install"
 
-# NOTE: this pin's vendored icsnVC40.h still predates Vspy 3.26.3.9
-# (SRADGalaxy2Settings 840 vs 1204, no Comet3/Gigastar2), so Linux/macOS
-# wheels lag the Windows ABI until upstream syncs the header; bump again
-# when it does. libicsneo requires icspb (protobuf) as of 2026: its
-# codegen needs the Ninja generator (protobuf_generate never creates
-# PROTOC_OUT_DIR; Make doesn't pre-create declared output dirs, Ninja
-# does), and it bootstraps protobuf from source at configure time — see
-# ICSPB_BOOTSTRAP_DIR below.
-LIBICSNEO_VERSION = "4ed29b4"
+# libicsneo master 2026-07-08; its vendored icsnVC40.h is byte-identical
+# to include/ics/icsnVC40.h (Vspy 3.26.3.9), so Linux/macOS wheels match
+# the Windows ABI. Keep the two headers in lockstep on future bumps.
+# libicsneo requires icspb (protobuf) as of 2026: its codegen needs the
+# Ninja generator (protobuf_generate never creates PROTOC_OUT_DIR; Make
+# doesn't pre-create declared output dirs, Ninja does), and it bootstraps
+# protobuf from source at configure time — see ICSPB_BOOTSTRAP_DIR below.
+LIBICSNEO_VERSION = "0dd8dbf"
 LIBICSNEO_ROOT = f"{ROOT}/libicsneo/{LIBICSNEO_VERSION}"
 LIBICSNEO_SOURCE = f"{LIBICSNEO_ROOT}/source"
 LIBICSNEO_BUILD = f"{LIBICSNEO_ROOT}/build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ requires = [
   "wheel",
   "dunamai",
   "pytest>=8.4.2",
+  # Puts the ninja executable on the isolated build env's PATH; required by
+  # build_libicsneo.py's `cmake -G Ninja` on Linux/macOS (see comments there).
+  "ninja",
 ]
 
 


### PR DESCRIPTION
libicsneo now permanently depends on **icspb** (protobuf), so python_ics's Linux/macOS wheel builds must build it. The previous attempt to bump the pin (#234 follow-up) failed CI with:

```
_deps/icspb-build/protos/: No such file or directory
make[3]: *** [_deps/icspb-build/protos/settings/manufacturing/v1/mfg_config.pb.h] Error 1
```

## Root cause

protobuf v33's `protobuf_generate()` (used by icspb) declares the generated `.pb.h/.pb.cc` as custom-command outputs but never creates `PROTOC_OUT_DIR` — and protoc does not create its own output root. The **Ninja** generator pre-creates directories for declared outputs; **Unix Makefiles** (what `build_libicsneo.py` used by default) does not. A/B-verified in docker on the same libicsneo commit (`4ed29b4`): Makefiles reproduces the exact CI error, Ninja builds clean.

## Changes

- Bump `LIBICSNEO_VERSION` to current master `4ed29b4`
- Configure libicsneo with `-G Ninja` on Linux/macOS; add `ninja` to `[build-system] requires` so the binary is on the isolated build env's PATH in every cibuildwheel environment
- Set `ICSPB_BOOTSTRAP_DIR` to a shared root outside the libicsneo build dir: icspb compiles protobuf **from source at configure time**, and the Linux job builds 5 Pythons × 2 archs with a `git clean` between each — sharing the bootstrap (it self-partitions by `<system>-<processor>`) means one protobuf compile per arch instead of ten. This matters most for aarch64 under QEMU.
- macOS: pass `CMAKE_OSX_ARCHITECTURES`/`CMAKE_OSX_DEPLOYMENT_TARGET` as **environment variables** too — icspb's nested protobuf bootstrap is a separate `execute_process` cmake that inherits env but not `-D` cache entries, and would otherwise produce arm64-only static libs that break the universal2 link.

## Verification

- Docker A/B on `4ed29b4`: Makefiles → exact CI failure; Ninja → `icspb` target builds.
- Full local `cibuildwheel --only cp312-manylinux_x86_64` run with these changes: wheel builds end-to-end; `libicsneolegacy.so` contains the icspb proto descriptors and protobuf runtime; wheel passes `check-wheel-contents --ignore W009,W010`.
- macOS universal2 is exercised by this PR's CI.

## ABI parity (updated)

The header sync landed upstream: the pin is now master `0dd8dbf`, whose vendored `icsnVC40.h` is **byte-identical** to this repo's 3.26.3.9 header (verified). Linux/macOS wheels now match the Windows ABI — Galaxy2 1204, Comet3 918, Gigastar2 2400, GLOBAL_SETTINGS 2406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
